### PR TITLE
Added whereLike() method

### DIFF
--- a/Enumerable.php
+++ b/Enumerable.php
@@ -421,6 +421,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return static
      */
     public function whereInstanceOf($type);
+    
+    /**
+     * Filter any string items which match the given search term.
+     *
+     * @param  string  $key
+     * @param  string  $term
+     * @throws Exception
+     * @return static
+     */
+    public function whereLike($key, $term);
 
     /**
      * Get the first item from the enumerable passing the given truth test.

--- a/Traits/EnumeratesValues.php
+++ b/Traits/EnumeratesValues.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
@@ -674,6 +675,27 @@ trait EnumeratesValues
     {
         return $this->filter(function ($value) use ($type) {
             return $value instanceof $type;
+        });
+    }
+
+    /**
+     * Filter any string items which match the given search term.
+     *
+     * @param  string  $key
+     * @param  string  $term
+     * @throws Exception
+     * @return static
+     */
+    public function whereLike($key, $term)
+    {
+        if (!is_string($term)) {
+            throw new Exception("Property \"term\" must be an instance of string.");
+        }
+
+        return $this->filter(function ($item) use ($key, $term) {
+            $value = Str::lower(data_get($item, $key));
+
+            return Str::contains($value, Str::lower($term));
         });
     }
 


### PR DESCRIPTION
## What does this PR add?

This PR adds the "whereLike()" method which filters any items which match the given search term, when the item is a string. For example: 

```php
return Users::all()->whereLike('email', '@gmail.com');
```

It also uses the data_get method so it supports dot-notation as well.

@codepotato and I built this together.