### PR TITLE
Throw exception when trying to access Array Key exists on Object.

### DIFF
--- a/Arr.php
+++ b/Arr.php
@@ -152,6 +152,10 @@ class Arr
             return $array->offsetExists($key);
         }
 
+        if (is_object($array)) {
+            throw new InvalidArgumentException('Array must be type of Enumerable, ArrayAccess or array. Object Provided.);
+        }
+        
         return array_key_exists($key, $array);
     }
 


### PR DESCRIPTION
Improves traceability of error when using array key exists on Object.

"message": "array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead",
    "exception": "ErrorException",
    "file": "C:\\sites\\procure\\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\Arr.php",
    "line": 155,
    "trace": [
        {
            "function": "handleError",
            "class": "Illuminate\\Foundation\\Bootstrap\\HandleExceptions",
            "type": "->"
        },
        {
            "file": "C:\\sites\\procure\\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\Arr.php",
            "line": 155,
            "function": "array_key_exists"
        },
        {
            "file": "C:\\sites\\procure\\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\Arr.php",
            "line": 253,
            "function": "exists",
            "class": "Illuminate\\Support\\Arr",
            "type": "::"
        },
        {
            "file": "C:\\sites\\procure\\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\Arr.php",
            "line": 491,
            "function": "forget",
            "class": "Illuminate\\Support\\Arr",
            "type": "::"
        },
        {
            "file": "C:\\sites\\procure\\vendor\\laravel\\framework\\src\\Illuminate\\Http\\UploadedFile.php",
            "line": 84,
            "function": "pull",
            "class": "Illuminate\\Support\\Arr",
            "type": "::"
        },