### PR TITLE
Add firstAttribute method

### DIFF
--- a/Collection.php
+++ b/Collection.php
@@ -363,15 +363,16 @@ class Collection implements ArrayAccess, Enumerable
      * Get an attribute from the first item from the collection passing the given truth test.
      *
      * @param  string  $attribute
-     * @param  string  $defaultValue
+     * @param  mixed  $defaultValue
      * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
      */
-    public function firstAttribute(string $attribute, string $defaultValue = null, callable $callback = null, $default = null)
+    public function firstAttribute(string $attribute, $defaultValue = null, callable $callback = null, $default = null)
     {
         $item = $this->first($callback, $default);
-        return ($item || is_null($defaultValue)) ? $item->$attribute : $defaultValue;
+  
+        return $item ? $item->$attribute : $defaultValue;
     }
 
     /**


### PR DESCRIPTION
There are times when you need to retrieve an attribute from a collection item if it exists, and return a separate default value if it doesn't.

This would currently be done like this:

`$user = $users->where('name', 'Bob Smith')->first();`
`$age = $user ? $user->age : "Unknown";`

What I really want is to be able to do:
`$age = $users->where('name', 'Bob Smith')->first()->age ?? "Unknown";`

But of course this will throw an exception if Bob Smith doesn't exist.

This sugar method allows you to do:

`$age = $users->where('name', 'Bob Smith')->firstAttribute('age', 'Unknown');`

The existing `$default` param in `first()` would require you to create an empty model for this to work.

**Note:** with this implementation, you wouldn't know whether there was an item and its attribute value was equal to defaultValue, or whether there wasn't an item and you had received the defaultValue in return. You should use other methods to determine existence.