### PR TITLE
BUG-fix-missing-dumpable-trait

### DIFF
--- a/Traits/Dumpable.php
+++ b/Traits/Dumpable.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Dumpable
+{
+    /**
+     * Dump the given arguments and terminate execution.
+     *
+     * @param  mixed  ...$args
+     * @return never
+     */
+    public function dd(...$args)
+    {
+        $this->dump(...$args);
+
+        dd();
+    }
+
+    /**
+     * Dump the given arguments.
+     *
+     * @param  mixed  ...$args
+     * @return $this
+     */
+    public function dump(...$args)
+    {
+        dump($this, ...$args);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
- as this package should work without illuminate/support we should add dumpable trait because it's use in EnumeratesValues and  it's in Illuminate/support which we should not add it to composer.json